### PR TITLE
Update NDFA.__tostring to use the self.regex.

### DIFF
--- a/re.lua
+++ b/re.lua
@@ -280,7 +280,7 @@ function NDFA:step(input)
 end
 
 function NDFA.__tostring(self)
-	return "NDFA: " .. self
+	return "NDFA: " .. self.regex
 end
 
 --function eClosure(NDFA, Int) return {State:[Function]} List of all states accessible via epsilon transitions from the given state, and a list of functions to execute for that state. This function is cached, and the returned table should NOT be modified.


### PR DESCRIPTION
To avoid an error with trying to print `self` instead include
the regex in the string output.

Fixes #6 