### PR TITLE
Fix handling of multiple escaping

### DIFF
--- a/reParse.lua
+++ b/reParse.lua
@@ -62,12 +62,15 @@ grammar["*"]=newRepetition("STAR")
 grammar["?"]=newRepetition("QUESTION")
 grammar["["]=function(root,stack,str)
 	local i=0
+	local escaped = false
 	for c in str:gmatch(".") do
 		i = i+1
 		if c == ESC and not escaped then 
 			escaped = true
 		elseif c == "]" and not escaped then
 			break
+		elseif escaped then
+			escaped = false
 		end
 	end
 	local class = CharacterClass( "["..str:sub(1,i))

--- a/reParse.lua
+++ b/reParse.lua
@@ -118,6 +118,7 @@ function P.parse(regex)
 		local rest= regex:sub(i+1) or ""
 		print("p:", c, rest)
 		if escaped then
+			escaped = false
 			if grammar[ ESC .. c ] then
 				root = grammar[ESC..c](root, stack)
 			else

--- a/re_spec.lua
+++ b/re_spec.lua
@@ -42,4 +42,30 @@ describe("re execute", function()
 		assert.regex_matches(ESC .. "." .. ESC .. "..", "..a")
 		assert.not_regex_matches(ESC .. "." .. ESC .. "..", ".ab")
 	end)
+
+	describe("character classes", function()
+		it("should match basic classes", function()
+			assert.regex_matches("ab[cdef]+gh", "abcgh")
+			assert.regex_matches("ab[cdef]+gh", "abcdegh")
+			assert.not_regex_matches("ab[cdef]+gh", "abzgh")
+		end)
+
+		it("should allow ']' to be escaped", function()
+			assert.regex_matches("a[b" .. ESC .. "]]+gh." .. ESC .. ".", "ab]gh!.")
+		end)
+
+		it("should allow / to be escaped", function()
+		assert.regex_matches("a[" .. ESC .. ESC .. "]+gh." .. ESC .. ".",
+			"a" .. ESC .. ESC .. "gh!.")
+		end)
+
+		it("shouldn't affect escaping outside the class", function()
+			assert.regex_matches("[a" .. ESC .. "]]+b" .. ESC .. ".", "a]ab.")
+			assert.not_regex_matches("[a" .. ESC .. "]]+b" .. ESC .. ".", "a]ab!")
+		end)
+
+		it("should not include / in the class", function()
+			assert.not_regex_matches("a[b" .. ESC .. "]]+c", "a" .. ESC .. "c")
+		end)
+	end)
 end)

--- a/re_spec.lua
+++ b/re_spec.lua
@@ -37,5 +37,9 @@ describe("re execute", function()
 		assert.regex_matches("abc" .. ESC .. "+abc", "abc+abc")
 		assert.regex_matches(ESC .. ".", ".")
 		assert.not_regex_matches(ESC .. ".", "!")
+
+		-- Multiple escapes
+		assert.regex_matches(ESC .. "." .. ESC .. "..", "..a")
+		assert.not_regex_matches(ESC .. "." .. ESC .. "..", ".ab")
 	end)
 end)


### PR DESCRIPTION
Previously including an escaped character in the regex set `escaped` mode for all future characters.

This PR fixes that issue for both character-class escapes and non-character-class.